### PR TITLE
makefile help for clangd lsp

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -10,5 +10,10 @@ vdrm-objs:=vdrm_main.o \
 all:
 	make -C $(KDIR) M=$(PWD) modules
 
+compile_commands:
+	make -C $(KDIR) M=$(PWD) compile_commands.json
+
 clean:
+	cp compile_commands.json compile_commands.json.tmp
 	make -C $(KDIR) M=$(PWD) clean
+	mv compile_commands.json.tmp compile_commands.json


### PR DESCRIPTION
clangd doesn't automatically index header file

compile_commands.json need to be created

some compile argument can make issues.

exmaple for `.clangd` file to remove them:
```
CompileFlags:
  Remove: 
    - -mrecord-mcount
    - -fconserve-stack
    - -fno-allow-store-data-races
    - -mindirect-branch-register
    - -mindirect-branch=thunk-extern
    - -mpreferred-stack-boundary=3
```